### PR TITLE
Run rubocop with --force-exclusion

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -15,6 +15,7 @@
       "args": [
         "exec",
         "rubocop",
+        "--force-exclusion",
         "--format",
         "json",
         "--stdin",


### PR DESCRIPTION
Adding `--force-exclusion` to coc config when running rubocop on current file so that it respects the Exclude configs from the project's `.rubocop.yml`

Explanation https://github.com/castwide/vscode-solargraph/issues/155#issuecomment-573130178
> The way RuboCop handles excluded_files is a little confusing. When you run RuboCop on a directory, it uses the configuration. When you run it on a specific file, it assumes that you want a report regardless of whether the file is excluded. Solargraph runs RuboCop on the file when you open it in an editor, so you get the latter behavior.

From `rubocop --help`

```
        --force-exclusion            Force excluding files specified in the
                                     configuration `Exclude` even if they are
                                     explicitly passed as arguments.
```

