### PR TITLE
Switch default editor and aliases from vim to nvim

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,5 +1,5 @@
-alias v="vim"
-alias vf='vim $(fzf)'
+alias v="nvim"
+alias vf='nvim $(fzf)'
 alias g="git"
 alias gg="git grep"
 alias gd="git diff"

--- a/.zshrc
+++ b/.zshrc
@@ -25,7 +25,7 @@ select-word-style bash
 # ============================================================
 
 export TERM=xterm-256color
-export EDITOR=vim
+export EDITOR=nvim
 export PAGER=less
 export CLICOLOR=1
 


### PR DESCRIPTION
## Summary
- `EDITOR=nvim` in `.zshrc`
- `v` and `vf` aliases updated to use `nvim`