### PR TITLE
tmux: cleanup config

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,7 +1,5 @@
 # Setting the prefix from C-b to C-a
 # set -g prefix C-a
-
-# Free the original Ctrl-b prefix keybinding
 # unbind C-b
 
 # Setting the delay between prefix and command
@@ -29,233 +27,80 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
-# Deprecated in favor of using Alacritty key bindings to send command to tmux
-# see https://github.com/alacritty/alacritty/issues/820#issuecomment-651385928
-
-# Faster no-prefix move between panes: Ctrl+Shift+h/j/k/l
-#
-# https://github.com/tmux/tmux/issues/1043
-# https://man7.org/linux/man-pages/man1/tmux.1.html
-# https://superuser.com/questions/1372254/what-are-the-tmux-conf-bindings-for-ctrl-shift-keyboard-shortcuts-with-cygwin-m
-#
-# This depends on following key bindings in `.alacritty.yml`:
-# ```
-# - { key: H,  mods: Control|Shift, chars: "\x1b[72;5u"                  }
-# - { key: J,  mods: Control|Shift, chars: "\x1b[74;5u"                  }
-# - { key: K,  mods: Control|Shift, chars: "\x1b[75;5u"                  }
-# - { key: L,  mods: Control|Shift, chars: "\x1b[76;5u"                  }
-# ```
-# set -s user-keys[0] "\e[72;5u" # C-S-h
-# set -s user-keys[1] "\e[74;5u" # C-S-j
-# set -s user-keys[2] "\e[75;5u" # C-S-k
-# set -s user-keys[3] "\e[76;5u" # C-S-l
-# # unbind -n UserKey0
-# # unbind -n UserKey1
-# # unbind -n UserKey2
-# # unbind -n UserKey3
-# bind -n UserKey0 select-pane -L
-# bind -n UserKey1 select-pane -D
-# bind -n UserKey2 select-pane -U
-# bind -n UserKey3 select-pane -R
-
 # Quick window selection
 bind -r C-h select-window -t :-
 bind -r C-l select-window -t :+
-# Quicker no-prefix window selection
-# Need to disable OSX shortcuts in System Preferences > Keyboard > Shortcuts > Mission Control
+
+# No-prefix window selection
 bind -n C-Left select-window -t :-
 bind -n C-Right select-window -t :+
 
-# Pane resizing panes with Prefix H,J,K,L
+# Move window left/right
+bind -n C-S-Left swap-window -t -1\; select-window -t -1
+bind -n C-S-Right swap-window -t +1\; select-window -t +1
+
+# Pane resizing with Prefix H,J,K,L
 bind -r H resize-pane -L 3
 bind -r J resize-pane -D 3
 bind -r K resize-pane -U 3
 bind -r L resize-pane -R 3
 
-# Move window left/right, then stay on the same window
-# Ctrl+Shift+Left/Right
-# https://superuser.com/a/552493
-bind -n C-S-Left swap-window -t -1\; select-window -t -1
-bind -n C-S-Right swap-window -t +1\; select-window -t +1
-
-# Mouse support - set to on if you want to use the mouse
+# Mouse support
 set -g mouse off
 
-# Set the default terminal mode to 256color mode
+# 256color + true color support
 set -g default-terminal "screen-256color"
-# set -g default-terminal "xterm-256color"
-
-# Enable true color in vim under tmux
-# https://github.com/tmux/tmux/issues/1246
 set -ga terminal-overrides ",*256col*:Tc"
 
-# Set the status line's colors
-# set -g status-style fg=white,bg=black
+# Pane borders
+set -g pane-border-style fg=colour8
+set -g pane-active-border-style fg=colour10
 
-# Set the color of the window list
-# setw -g window-status-style fg=cyan,bg=black
-
-# Set colors for the active window
-# setw -g window-status-current-style fg=white,bold,bg=red
-
-# Colors for pane borders
-set -g pane-border-style fg=colour8 #black #base02
-set -g pane-active-border-style fg=colour10 #base01
-
-# Active pane normal, other shaded out
-# setw -g window-style fg=colour240,bg=colour235
-# setw -g window-active-style fg=white,bg=black
-
-# Command / message line
-# set -g message-style fg=white,bold,bg=black
-
-# Status line left side to show Session:window:pane
-# set -g status-left-length 40
-# set -g status-left "#[fg=green]Session: #S #[fg=yellow]#I #[fg=cyan]#P"
-
-# Status line right side -  31-Oct 13:37
-# set -g status-right "#[fg=cyan]%d %b %R"
-
-# Update the status line every sixty seconds
-# set -g status-interval 60
-
-# Center the window list in the status line
-# set -g status-justify centre
-
-# enable activity alerts
+# Activity alerts
 setw -g monitor-activity on
 set -g visual-activity on
 
-# Try to set ayu theme
-# https://github.com/jibingeo/tmux-colors-ayu/blob/master/tmuxcolors-dark.conf
-# fg="#CBCCC6"
-# bg="#212732"
-# status_bg="#34455A"
-# border_fg="#70748C"
-# border_active_fg="#FECB6E"
-# status_left_bg="#FFA759"
-
-# set -g status-style "bg=$status_bg,fg=$fg"
-# set -g status-left-style "bg=$status_left_bg,fg=$fg"
-
-# Border
-# set -g pane-border-style "bg=$bg,fg=$border_fg"
-# set -g pane-active-border-style "bg=$bg,fg=$border_active_fg"
-
-# Window
-# set -g window-status-current-style "fg=$border_active_fg"
-# set -g window-status-style "fg=$fg"
-
-#==========================================
-# Try to match parts of vim confg
-# Tmux colors
-# https://superuser.com/questions/285381/how-does-the-tmux-color-palette-work
-set-option -g mode-style fg=colour55
-set-option -g mode-style bg=colour105
-
-#==========================================
-# Random shit I'm trying
-# Needed for CTRL-Left/Right to work.
+# Needed for CTRL-Left/Right to work
 setw -g xterm-keys on
 
-# Use vi key bindings in copy mode.
+# Vi key bindings in copy mode
 setw -g mode-keys vi
-
-# Key bindings for copy-mode
-# https://superuser.com/questions/395158/tmux-copy-mode-select-text-block
-bind-key -T copy-mode-vi 'v' send -X begin-selection     # Begin selection in copy mode.
-bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle  # Begin selection in copy mode.
-bind-key -T copy-mode-vi 'y' send -X copy-selection      # Yank selection in copy mode.
-
-# Search mode vi
 set-window-option -g mode-keys vi
 
-#==========================================
-# From https://thoughtbot.com/blog/love-hate-tmux
+# Copy mode key bindings
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle
+bind-key -T copy-mode-vi 'y' send -X copy-selection
 
-# Remove administrative debris (session name, hostname, time) in status bar
+# Status bar
 set -g status-left ''
-set -g status-right ''
+set -g status-right '#[fg=colour233,bg=colour19,bold] %B-%d#[fg=colour123,bg=colour8,bold] %R -#T'
+set -g status-interval 30
 
-#==========================================
-# From https://github.com/esparta/dotfiles/blob/main/tmux.conf
+set-option -g status-style bg=black,fg=yellow
+set-window-option -g window-style fg=brightblue,bg=default
+set-window-option -g window-status-current-style fg=brightred,bg=default
+set-option -g message-style bg=black,fg=brightred
+set-option -g display-panes-active-colour blue
+set-option -g display-panes-colour brightred
+set-window-option -g clock-mode-colour green
 
-# Use fish
-# set -g default-shell /usr/local/bin/fish
+set-option -g mode-style fg=colour55,bg=colour105
 
-# Increase scroll-back history
+# Scroll-back history
 set -g history-limit 100000
 
 # Re-number windows when one is closed
 set -g renumber-windows on
 
-###########################
-# Status Bar
-###########################
-
-set -g status-right '#[fg=colour233,bg=colour19,bold] %B-%d#[fg=colour123,bg=colour8,bold] %R -#T'
-# setw -g window-status-current-format '#I#[fg=colour249]:#[fg=colour255]#W#[fg=colour249]#F '
-
-# set refresh interval for status bar
-set -g status-interval 30
-
-# default statusbar colors
-set-option -g status-style bg=black #base02
-set-option -g status-style fg=yellow #yellow
-
-# default window title colors
-set-window-option -g window-style fg=brightblue #base0
-set-window-option -g window-style bg=default
-#set-window-option -g window-status-attr dim
-
-# active window title colors
-set-window-option -g window-status-current-style fg=brightred #orange
-set-window-option -g window-status-current-style bg=default
-
-# message text
-set-option -g message-style bg=black #base02
-set-option -g message-style fg=brightred #orange
-
-# pane number display
-set-option -g display-panes-active-colour blue #blue
-set-option -g display-panes-colour brightred #orange
-
-# clock
-set-window-option -g clock-mode-colour green #green
-
 #=========================================
-# Tmux plugin manager
-# https://github.com/tmux-plugins/tpm
+# Tmux plugin manager (tpm)
 set -g @plugin 'tmux-plugins/tpm'
 
 # Tmux resurrect
-# https://github.com/tmux-plugins/tmux-resurrect
 set -g @plugin 'tmux-plugins/tmux-resurrect'
-# Enable restore pane contents
 set -g @resurrect-capture-pane-contents 'on'
-
-# Set resurrect dir. Default: ~/.local/share/tmux/resurrect
-# https://github.com/tmux-plugins/tmux-resurrect/blob/master/docs/restoring_previously_saved_environment.md
-# https://github.com/tmux-plugins/tmux-resurrect/blob/master/docs/save_dir.md
-# > $XDG_DATA_HOME defines the base directory relative to which user-specific data files should be stored.
-# > If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME /. local/share should be used.
-# set -g @resurrect-dir '~/.local/share/tmux/resurrect'
-# Restore additional programs
-# https://github.com/tmux-plugins/tmux-resurrect/blob/master/docs/restoring_programs.md
-# See ~/.local/share/tmux/resurrect/last
-# For testing only to see what gets saved:
-# set -g @resurrect-processes ':all:'
 set -g @resurrect-processes '"npm start" "psql->psql *" "~heroku pg:psql->heroku pg:psql *" "puma->bundle exec rails s" "~script/rails c->bundle exec rails c"'
-
-# Tmux continuum (disabled)
-# https://github.com/tmux-plugins/tmux-continuum
-# set -g @plugin 'tmux-plugins/tmux-continuum'
-# Automatic start
-# https://github.com/tmux-plugins/tmux-continuum/blob/master/docs/automatic_start.md
-# set -g @continuum-boot 'on'
-# set -g @continuum-boot-options 'alacritty'
-# Continuum status
-# set -g status-right 'Continuum status: #{continuum_status}'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@
 ```sh
 ln -snf path/to/dotfiles/nvim ~/.config/nvim
 ln -snf path/to/dotfiles/ghostty/config.ghostty ~/.config/ghostty/config.ghostty
+ln -snf path/to/dotfiles/tmux/tmux.conf ~/.config/tmux/tmux.conf
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Setup
 
 ```sh
-ln -snf path/to/dotfiles/nvim ~/.config/nvim
-ln -snf path/to/dotfiles/ghostty/config.ghostty ~/.config/ghostty/config.ghostty
-ln -snf path/to/dotfiles/tmux/tmux.conf ~/.config/tmux/tmux.conf
+mkdir -p ~/.config/nvim && ln -snf path/to/dotfiles/nvim ~/.config/nvim
+mkdir -p ~/.config/ghostty && ln -snf path/to/dotfiles/ghostty/config.ghostty ~/.config/ghostty/config.ghostty
+mkdir -p ~/.config/tmux && ln -snf path/to/dotfiles/tmux/tmux.conf ~/.config/tmux/tmux.conf
 ```

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -15,7 +15,7 @@ set -g base-index 1
 setw -g pane-base-index 1
 
 # Reload the file with Prefix r
-bind r source-file ~/.tmux.conf \; display "Reloaded!"
+bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
 
 # Splitting panes with | and -
 bind | split-window -h
@@ -49,7 +49,7 @@ bind -r L resize-pane -R 3
 set -g mouse off
 
 # 256color + true color support
-set -g default-terminal "screen-256color"
+set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",*256col*:Tc"
 
 # Pane borders
@@ -96,11 +96,6 @@ set -g renumber-windows on
 #=========================================
 # Tmux plugin manager (tpm)
 set -g @plugin 'tmux-plugins/tpm'
-
-# Tmux resurrect
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @resurrect-capture-pane-contents 'on'
-set -g @resurrect-processes '"npm start" "psql->psql *" "~heroku pg:psql->heroku pg:psql *" "puma->bundle exec rails s" "~script/rails c->bundle exec rails c"'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -72,7 +72,6 @@ setw -g xterm-keys on
 
 # Vi key bindings in copy mode
 setw -g mode-keys vi
-set-window-option -g mode-keys vi
 
 # Copy mode key bindings
 bind-key -T copy-mode-vi 'v' send -X begin-selection

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -21,7 +21,7 @@ bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
 bind | split-window -h
 bind - split-window -v
 
-# Move between panes with Prefix h,j,k,l
+# Move between panes with Prefix h,j,k,l (prefix-based, no conflict with Ghostty)
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
@@ -44,6 +44,13 @@ bind -r H resize-pane -L 3
 bind -r J resize-pane -D 3
 bind -r K resize-pane -U 3
 bind -r L resize-pane -R 3
+
+# No-prefix pane nav (ctrl+shift+hjkl) disabled — conflicts with Ghostty split navigation.
+# Ghostty handles splits day-to-day; use prefix+hjkl above for tmux panes when needed.
+# bind -n C-S-h select-pane -L
+# bind -n C-S-j select-pane -D
+# bind -n C-S-k select-pane -U
+# bind -n C-S-l select-pane -R
 
 # Mouse support
 set -g mouse off


### PR DESCRIPTION
WIP — removing dead commented-out blocks and consolidating config. No behavior changes.

## Pending decisions
- Resurrect processes list: keep here or move project-specific entries to local config?
- `default-terminal`: keep `screen-256color` or switch to `tmux-256color` for Ghostty?
- Move to `tmux/tmux.conf` (XDG style, consistent with nvim/ and ghostty/)?