### PR TITLE
theme: switch from Ayu to Catppuccin

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -10,7 +10,7 @@ catppuccin() {
   local flavor="${1:-mocha}"
   sed -i '' "s/local flavour = .*/local flavour = \"$flavor\"/" ~/Projects/dotfiles/nvim/lua/plugins/ui.lua
   sed -i '' "s/theme = Catppuccin .*/theme = Catppuccin ${(C)flavor}/" ~/Projects/dotfiles/ghostty/config.ghostty
-  for socket in /tmp/nvim*/0; do
+  for socket in $(find "${TMPDIR}nvim.${USER}" -name "nvim.*.0" -type s 2>/dev/null); do
     nvim --server "$socket" --remote-send ":colorscheme catppuccin-$flavor<CR>" 2>/dev/null
   done
   echo "Switched to Catppuccin $flavor — reload Ghostty with Cmd+Shift+,"

--- a/.aliases
+++ b/.aliases
@@ -6,14 +6,16 @@ alias gd="git diff"
 alias gds="git diff --staged"
 alias gs="git status"
 
+alias ct="catppuccin"
+
 catppuccin() {
   local flavor="${1:-mocha}"
   sed -i '' "s/local flavour = .*/local flavour = \"$flavor\"/" ~/Projects/dotfiles/nvim/lua/plugins/ui.lua
   sed -i '' "s/theme = Catppuccin .*/theme = Catppuccin ${(C)flavor}/" ~/Projects/dotfiles/ghostty/config.ghostty
   for socket in $(find "${TMPDIR}nvim.${USER}" -name "nvim.*.0" -type s 2>/dev/null); do
-    nvim --server "$socket" --remote-send ":colorscheme catppuccin-$flavor<CR>" 2>/dev/null
+    nvim --server "$socket" --remote-send ":colorscheme catppuccin-$flavor<CR>:lua require('lualine').setup({ options = { theme = 'catppuccin-$flavor' } })<CR>" 2>/dev/null
   done
-  echo "Switched to Catppuccin $flavor — reload Ghostty with Cmd+Shift+,"
+  echo "✓ Catppuccin $flavor — reload Ghostty with Cmd+Shift+,"
 }
 
 [ -f ~/.aliases.local ] && source ~/.aliases.local

--- a/.aliases
+++ b/.aliases
@@ -18,4 +18,10 @@ catppuccin() {
   echo "✓ Catppuccin $flavor — reload Ghostty with Cmd+Shift+,"
 }
 
+_catppuccin_complete() {
+  local flavors=(mocha macchiato frappe latte)
+  compadd "$@" -- $flavors
+}
+compdef _catppuccin_complete catppuccin ct
+
 [ -f ~/.aliases.local ] && source ~/.aliases.local

--- a/.aliases
+++ b/.aliases
@@ -6,4 +6,14 @@ alias gd="git diff"
 alias gds="git diff --staged"
 alias gs="git status"
 
+catppuccin() {
+  local flavor="${1:-mocha}"
+  sed -i '' "s/local flavour = .*/local flavour = \"$flavor\"/" ~/Projects/dotfiles/nvim/lua/plugins/ui.lua
+  sed -i '' "s/theme = Catppuccin .*/theme = Catppuccin ${(C)flavor}/" ~/Projects/dotfiles/ghostty/config.ghostty
+  for socket in /tmp/nvim*/0; do
+    nvim --server "$socket" --remote-send ":colorscheme catppuccin-$flavor<CR>" 2>/dev/null
+  done
+  echo "Switched to Catppuccin $flavor — reload Ghostty with Cmd+Shift+,"
+}
+
 [ -f ~/.aliases.local ] && source ~/.aliases.local

--- a/ghostty/config.ghostty
+++ b/ghostty/config.ghostty
@@ -26,9 +26,9 @@ window-padding-x = 6
 window-padding-y = 6
 window-padding-balance = true
 
-background-opacity = 0.97
+background-opacity = 0.95
 background-blur = true
-unfocused-split-opacity = 0.82
+unfocused-split-opacity = 0.50
 
 # Nice on macOS
 macos-titlebar-style = transparent

--- a/ghostty/config.ghostty
+++ b/ghostty/config.ghostty
@@ -17,7 +17,7 @@ font-size = 12
 # ----------------------------
 # Colors
 # ----------------------------
-theme = Ayu
+theme = Catppuccin Mocha
 
 # ----------------------------
 # Window feel
@@ -29,7 +29,6 @@ window-padding-balance = true
 background-opacity = 0.97
 background-blur = true
 unfocused-split-opacity = 0.82
-split-divider-color = #0D2A3D
 
 # Nice on macOS
 macos-titlebar-style = transparent

--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -1,28 +1,22 @@
+local flavour = "mocha"
+
 return {
   -- Icons (used by lualine, telescope, oil)
   { "nvim-tree/nvim-web-devicons", lazy = true },
 
   -- Colorscheme
   {
-    "Shatur/neovim-ayu",
+    "catppuccin/nvim",
+    name = "catppuccin",
     lazy = false,
     priority = 1000,
-    config = function()
-      require("ayu").setup({
-        mirage = true,
-        overrides = {
-          Normal       = { bg = "None" },       -- use terminal background
-          LineNr       = { fg = "#6b6b47" },
-          Comment      = { fg = "#527077" },
-          Directory    = { fg = "#36A3D9" },
-          Search       = { fg = "#f5deb3", bg = "#6e2c71" },
-          CursorLine   = { bg = "#101068" },  -- blue row highlight
-          Whitespace   = { fg = "#c63f4f" },  -- trailing space indicator
-          IblIndent    = { fg = "#252b38" },  -- nearly invisible inactive guides
-          IblScope     = { fg = "#4d5566" },  -- visible scope highlight
-        },
-      })
-      vim.cmd("colorscheme ayu")
+    opts = {
+      flavour = flavour,
+      transparent_background = true,
+    },
+    config = function(_, opts)
+      require("catppuccin").setup(opts)
+      vim.cmd("colorscheme catppuccin")
     end,
   },
 
@@ -31,7 +25,7 @@ return {
     "nvim-lualine/lualine.nvim",
     dependencies = { "nvim-tree/nvim-web-devicons" },
     opts = {
-      options = { theme = "ayu_dark", section_separators = "", component_separators = "" },
+      options = { theme = "catppuccin-" .. flavour, section_separators = "", component_separators = "" },
       sections = {
         lualine_a = { "mode" },
         lualine_b = { "branch", "readonly", { "filename", path = 1 }, "modified" },
@@ -50,7 +44,7 @@ return {
       },
       tabline = {
         lualine_a = {},
-        lualine_b = { { "tabs", mode = 1, max_length = function() return vim.o.columns end, tabs_color = { active = { fg = "#B3B1AD", gui = "bold" }, inactive = { fg = "#5C6773" } }, fmt = function(name, ctx) return ctx.tabnr .. " " .. name end } },
+        lualine_b = { { "tabs", mode = 1, max_length = function() return vim.o.columns end, fmt = function(name, ctx) return ctx.tabnr .. " " .. name end } },
         lualine_c = {},
         lualine_x = {},
         lualine_y = {},
@@ -65,8 +59,8 @@ return {
     main = "ibl",
     event = "BufReadPost",
     opts = {
-      indent = { char = "│", highlight = "IblIndent" },
-      scope  = { enabled = true, highlight = "IblScope" },
+      indent = { char = "│" },
+      scope  = { enabled = true },
     },
   },
 


### PR DESCRIPTION
## Summary

- Replace `neovim-ayu` with `catppuccin/nvim` (defaults to mocha)
- Remove all custom hex color overrides — Catppuccin's defaults replace them cleanly
- Remove Ayu-specific `split-divider-color` from Ghostty config
- Add `ct` / `catppuccin()` shell function for live flavor switching across nvim + Ghostty
- Tune Ghostty split opacity for better inactive split visibility

## Usage

```sh
ct           # switch to mocha (default)
ct latte
ct frappe
ct macchiato
```

Updates both config files and sends `:colorscheme` + lualine reload to all running nvim instances. Reload Ghostty with `Cmd+Shift+,`.

## Test plan

- [ ] `:Lazy sync` in nvim to install catppuccin and remove neovim-ayu
- [ ] Restart nvim — Catppuccin Mocha loads correctly
- [ ] `ct latte` switches nvim and Ghostty theme live