### PR TITLE
nvim: add ts-comments.nvim for reliable commentstring support

### DIFF
--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -1,5 +1,10 @@
 return {
   {
+    "folke/ts-comments.nvim",
+    event = "VeryLazy",
+    opts = {},
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
     dependencies = { "nvim-treesitter/nvim-treesitter-textobjects" },


### PR DESCRIPTION
## Why

Neovim's built-in `gc`/`gcc` commenting (added in 0.10) sometimes fails with `Option 'commentstring' is empty` for filetypes it doesn't recognize. It also uses the wrong comment syntax in JSX/TSX files (e.g. `//` instead of `{/* */}` inside JSX elements).

`folke/ts-comments.nvim` fixes this by maintaining a comprehensive table of correct commentstrings per language/node type, enhancing the built-in without replacing it. This is what LazyVim ships by default.

## What changed

Added `ts-comments.nvim` to `treesitter.lua` — it loads lazily on `VeryLazy` and requires no configuration.

## How to test

1. Run `:Lazy sync` in nvim to install
2. Open a `.tsx` file and place cursor **inside** a JSX element (between the tags)
3. Press `gcc` — should produce `{/* comment */}` not `// comment`
4. Place cursor on a regular JS line outside JSX and press `gcc` — should produce `// comment`

Without this plugin, step 3 would either error or use the wrong syntax.