### PR TITLE
nvim: add terminal keymaps and claudecode.nvim plugin

### DIFF
--- a/nvim/lua/keymaps.lua
+++ b/nvim/lua/keymaps.lua
@@ -4,6 +4,10 @@ local map = vim.keymap.set
 map({ "n", "v", "o" }, ";", ":", { noremap = true })
 map({ "n", "v", "o" }, ";;", ";", { noremap = true })
 
+-- Terminal mode
+map("t", "<C-x>", "<C-\\><C-n>",        { noremap = true, desc = "Exit terminal mode" })
+map("t", "<C-h>", "<C-\\><C-n><C-w>h",  { noremap = true, desc = "Exit terminal and go left" })
+
 -- Split navigation
 map("n", "<C-h>", "<C-w>h", { noremap = true })
 map("n", "<C-j>", "<C-w>j", { noremap = true })

--- a/nvim/lua/plugins/claude.lua
+++ b/nvim/lua/plugins/claude.lua
@@ -1,0 +1,38 @@
+return {
+  {
+    "coder/claudecode.nvim",
+    dependencies = { "folke/snacks.nvim" },
+    opts = {
+      terminal_cmd = "~/.local/bin/claude",
+      terminal = {
+        snacks_win_opts = {
+          position = "right",
+          width = 0.45,
+          border = "rounded",
+          keys = {
+            claude_hide = {
+              "<leader>ac",
+              function(self) self:hide() end,
+              mode = "t",
+              desc = "Hide Claude",
+            },
+          },
+        },
+      },
+    },
+    config = true,
+    keys = {
+      { "<leader>a",  nil,                                desc = "AI/Claude Code" },
+      { "<leader>ac", "<cmd>ClaudeCode<cr>",              desc = "Toggle Claude" },
+      { "<leader>af", "<cmd>ClaudeCodeFocus<cr>",         desc = "Focus Claude" },
+      { "<leader>ar", "<cmd>ClaudeCode --resume<cr>",     desc = "Resume Claude" },
+      { "<leader>aC", "<cmd>ClaudeCode --continue<cr>",   desc = "Continue Claude" },
+      { "<leader>am", "<cmd>ClaudeCodeSelectModel<cr>",   desc = "Select Claude model" },
+      { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>",         desc = "Add current buffer" },
+      { "<leader>as", "<cmd>ClaudeCodeSend<cr>",          mode = "v", desc = "Send to Claude" },
+      { "<leader>as", "<cmd>ClaudeCodeTreeAdd<cr>",       desc = "Add file", ft = { "NvimTree", "neo-tree", "oil", "minifiles", "netrw" } },
+      { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>",    desc = "Accept diff" },
+      { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>",      desc = "Deny diff" },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add terminal mode keymaps (`<C-x>` to exit terminal, `<C-h>` to exit and move left)
- Add `claudecode.nvim` plugin config with `<leader>a*` keymaps for Claude Code integration (toggle, focus, resume, continue, model select, buffer add, send selection, diff accept/deny)